### PR TITLE
Zarr fixes

### DIFF
--- a/cellprofiler_core/modules/loaddata.py
+++ b/cellprofiler_core/modules/loaddata.py
@@ -1062,11 +1062,18 @@ safe to press it.""",
         if url.endswith('.zarr'):
             # Zarrs need czt indexing rather than just index.
             c, z, t = None, None, None
-            if measurements.has_feature("Image", "Metadata_C"):
+
+            if measurements.has_feature(f"Channel_{name}"):
+                c = measurements["Image", f"Channel_{name}"]
+            elif measurements.has_feature("Image", "Metadata_C"):
                 c = measurements["Image", "Metadata_C"]
-            if measurements.has_feature("Image", "Metadata_Z"):
+            if measurements.has_feature(f"Z_{name}"):
+                z = measurements["Image", f"Z_{name}"]
+            elif measurements.has_feature("Image", "Metadata_Z"):
                 z = measurements["Image", "Metadata_Z"]
-            if measurements.has_feature("Image", "Metadata_T"):
+            if measurements.has_feature(f"T_{name}"):
+                t = measurements["Image", f"T_{name}"]
+            elif measurements.has_feature("Image", "Metadata_T"):
                 t = measurements["Image", "Metadata_T"]
             return FileImage(
                 name,

--- a/cellprofiler_core/modules/loaddata.py
+++ b/cellprofiler_core/modules/loaddata.py
@@ -1063,15 +1063,15 @@ safe to press it.""",
             # Zarrs need czt indexing rather than just index.
             c, z, t = None, None, None
 
-            if measurements.has_feature(f"Channel_{name}"):
+            if measurements.has_feature("Image", f"Channel_{name}"):
                 c = measurements["Image", f"Channel_{name}"]
             elif measurements.has_feature("Image", "Metadata_C"):
                 c = measurements["Image", "Metadata_C"]
-            if measurements.has_feature(f"Z_{name}"):
+            if measurements.has_feature("Image", f"Z_{name}"):
                 z = measurements["Image", f"Z_{name}"]
             elif measurements.has_feature("Image", "Metadata_Z"):
                 z = measurements["Image", "Metadata_Z"]
-            if measurements.has_feature(f"T_{name}"):
+            if measurements.has_feature("Image", f"T_{name}"):
                 t = measurements["Image", f"T_{name}"]
             elif measurements.has_feature("Image", "Metadata_T"):
                 t = measurements["Image", "Metadata_T"]

--- a/cellprofiler_core/preferences/__init__.py
+++ b/cellprofiler_core/preferences/__init__.py
@@ -85,7 +85,8 @@ def get_config():
         try:
             app = wx.App(0)
         except SystemExit:
-            print("Running a build, no app available")
+            # We're probably building on GitHub Actions
+            print("Python version doesn't support GUI, no app available.")
             return __headless_config
         config = wx.Config.Get(False)
     if not config:

--- a/cellprofiler_core/preferences/__init__.py
+++ b/cellprofiler_core/preferences/__init__.py
@@ -82,7 +82,11 @@ def get_config():
     try:
         config = wx.Config.Get(False)
     except wx.PyNoAppError:
-        app = wx.App(0)
+        try:
+            app = wx.App(0)
+        except SystemExit:
+            print("Running a build, no app available")
+            return __headless_config
         config = wx.Config.Get(False)
     if not config:
         wx.Config.Set(

--- a/cellprofiler_core/utilities/zarr.py
+++ b/cellprofiler_core/utilities/zarr.py
@@ -21,7 +21,7 @@ def get_zarr_metadata(url):
     xmlfile = 'METADATA.ome.xml'
     parser = urllib.parse.urlparse(url)
     if parser.scheme == 'file':
-        url = parser.path
+        url = url2pathname(url)
     elif parser.scheme == 's3':
         client = boto3.client('s3')
         bucket_name, key = re.compile('s3://([\w\d\-\.]+)/(.*)').search(


### PR DESCRIPTION
As discussed with Emil, columns like Channel_DAPI, Z_DAPI and T_DAPI can now be used to index zarrs in LoadData. Also fixed metadata extraction in Windows and fixed a PyInstaller-related crash when building.